### PR TITLE
Feature: ApplicationX

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,14 @@
 sudo: true
 language: elixir
 elixir:
-  - 1.8.2
+  - 1.9.2
 otp_release:
   - 22.0
 matrix:
   include:
-    - elixir: 1.7.8
-      otp_release: 21.0
     - elixir: 1.8.2
+      otp_release: 21.0
+    - elixir: 1.9.2
       otp_release: 22.0
 script:
   - mix analyze --non-interactive

--- a/README.md
+++ b/README.md
@@ -25,11 +25,20 @@ The docs can be found at [https://hexdocs.pm/common_x](https://hexdocs.pm/common
 
 The following modules have extension:
 
+ - `ApplicationX` (`Application` extension)
  - `EnumX` (`Enum` extension)
  - `MapX` (`Map` extension)
  - `Macro` (`Macro` extension)
 
 ## Changelog
+
+### 20??-??-?? (v?.?.?)
+
+- Add `ApplicationX` extension with the following methods:
+  - `applications/0` list all applications, without starting.
+  - `applications/1` list all dependencies, without starting.
+  - `modules/0` list all modules, without starting applications.
+  - `modules/1` list all modules in given applications, without starting them.
 
 ### 2019-01-01 (v0.0.2)
 

--- a/lib/common_x/application_x.ex
+++ b/lib/common_x/application_x.ex
@@ -1,0 +1,160 @@
+defmodule ApplicationX do
+  @moduledoc ~S"""
+  Application module extended functions.
+  """
+  alias Mix.{Project, Task}
+  @ignore [:kernel, :stdlib, :elixir, :logger]
+  @load_error 'no such file or directory'
+
+  @doc ~S"""
+  List all available applications excluding system ones.
+
+  This function is save to run in `Mix.Task`s.
+
+  ## Example
+
+  Since `:common_x` does not have any dependencies:
+  ```elixir
+  iex> ApplicationX.applications
+  [:common_x]
+  ```
+  """
+  @spec applications :: [atom]
+  def applications do
+    main_app = Project.config()[:app]
+    with {:error, {@load_error, _}} <- :application.load(main_app), do: Task.run("loadpaths", [])
+
+    gather_applications([main_app])
+  end
+
+  @doc ~S"""
+  List all dependant applications excluding system ones.
+  Does includes the given application.
+
+  This function is save to run in `Mix.Task`s.
+
+  ## Example
+
+  Since `:common_x` does not have any dependencies:
+  ```elixir
+  iex> ApplicationX.applications(:common_x)
+  [:common_x]
+  ```
+
+  Duplicates are ignored and only returned once:
+  ```elixir
+  iex> ApplicationX.applications([:common_x, :common_x])
+  [:common_x]
+  ```
+
+  Unknown applications are safe, but returned:
+  ```elixir
+  iex> ApplicationX.applications(:fake)
+  [:fake]
+  ```
+  """
+  @spec applications(atom | [atom]) :: [atom]
+  def applications(app) when is_atom(app), do: gather_applications([app])
+  def applications(apps), do: gather_applications(apps)
+
+  @doc ~S"""
+  List all available modules excluding system ones.
+
+  This function is save to run in `Mix.Task`s.
+
+  ## Example
+
+  Since `:common_x` does not have any dependencies:
+  ```elixir
+  iex> ApplicationX.modules
+  [ApplicationX, CommonX, EnumX, MacroX, MapX]
+  ```
+  """
+  @spec modules :: [module]
+  def modules do
+    main_app = Project.config()[:app]
+    with {:error, {@load_error, _}} <- :application.load(main_app), do: Task.run("loadpaths", [])
+
+    modules(main_app)
+  end
+
+  @doc ~S"""
+  List all available modules for the given app[s] and dependencies of those apps.
+  This excludes system modules.
+
+  This function is save to run in `Mix.Task`s.
+
+  ## Example
+
+  Normally system modules are excluded,
+  but can be added by manually passing the respective system application:
+  ```elixir
+  iex> ApplicationX.modules(:logger)
+  [Logger, Logger.App, Logger.BackendSupervisor, Logger.Backends.Console,
+    Logger.Config, Logger.ErlangHandler, Logger.ErrorHandler, Logger.Formatter,
+    Logger.Translator, Logger.Utils, Logger.Watcher]
+  ```
+
+  Duplicate applications are ignored:
+  ```elixir
+  iex> ApplicationX.modules([:logger, :logger])
+  [Logger, Logger.App, Logger.BackendSupervisor, Logger.Backends.Console,
+    Logger.Config, Logger.ErlangHandler, Logger.ErrorHandler, Logger.Formatter,
+    Logger.Translator, Logger.Utils, Logger.Watcher]
+  ```
+
+  Unknown applications are safe to pass:
+  ```elixir
+  iex> ApplicationX.modules(:fake)
+  []
+  ```
+  """
+  @spec modules(atom | [atom]) :: [module]
+  def modules(app) when is_atom(app), do: gather_modules([app])
+  def modules(apps), do: gather_modules(apps)
+
+  ### Helpers ###
+
+  @spec gather_applications([atom], [atom]) :: [atom]
+  defp gather_applications(apps, acc \\ [])
+  defp gather_applications([], acc), do: acc
+
+  defp gather_applications([app | t], acc) do
+    if app in acc do
+      gather_applications(t, acc)
+    else
+      :application.load(app)
+
+      gather =
+        case :application.get_all_key(app) do
+          {:ok, data} -> t ++ ((data[:applications] || []) -- @ignore)
+          _ -> t
+        end
+
+      gather_applications(gather, [app | acc])
+    end
+  end
+
+  @spec gather_modules([atom], %{required(atom) => [module]}) :: [module]
+  defp gather_modules(apps, acc \\ %{})
+  defp gather_modules([], acc), do: acc |> Map.values() |> List.flatten()
+
+  defp gather_modules([app | t], acc) do
+    if Map.has_key?(acc, app) do
+      gather_modules(t, acc)
+    else
+      :application.load(app)
+
+      case :application.get_all_key(app) do
+        {:ok, data} ->
+          gather_modules(
+            t ++ ((data[:applications] || []) -- @ignore),
+            Map.put(acc, app, data[:modules] || [])
+          )
+
+        _ ->
+          gather_modules(t, acc)
+      end
+    end
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -19,7 +19,7 @@ defmodule CommonX.MixProject do
         "coveralls.post": :test,
         "coveralls.html": :test
       ],
-      dialyzer: [ignore_warnings: ".dialyzer", plt_add_deps: true],
+      dialyzer: [ignore_warnings: ".dialyzer", plt_add_deps: true, plt_add_apps: [:mix]],
 
       # Docs
       name: "CommonX",

--- a/test/common_x/application_x_test.exs
+++ b/test/common_x/application_x_test.exs
@@ -1,0 +1,4 @@
+defmodule ApplicationXTest do
+  use ExUnit.Case, async: true
+  doctest ApplicationX
+end


### PR DESCRIPTION
Add `ApplicationX` extension with the following methods:
  - `applications/0` list all applications, without starting.
  - `applications/1` list all dependencies, without starting.
  - `modules/0` list all modules, without starting applications.
  - `modules/1` list all modules in given applications, without starting them.

## Examples
### Applications

  Since `:common_x` does not have any dependencies:
  ```elixir
  iex> ApplicationX.applications
  [:common_x]
  ```

  ```elixir
  iex> ApplicationX.applications(:common_x)
  [:common_x]
  ```

  Duplicates are ignored and only returned once:
  ```elixir
  iex> ApplicationX.applications([:common_x, :common_x])
  [:common_x]
  ```

  Unknown applications are safe, but returned:
  ```elixir
  iex> ApplicationX.applications(:fake)
  [:fake]
  ```
### Modules
  Since `:common_x` does not have any dependencies:
  ```elixir
  iex> ApplicationX.modules
  [ApplicationX, CommonX, EnumX, MacroX, MapX]
  ```

  Normally system modules are excluded,
  but can be added by manually passing the respective system application:
  ```elixir
  iex> ApplicationX.modules(:logger)
  [Logger, Logger.App, Logger.BackendSupervisor, Logger.Backends.Console,
    Logger.Config, Logger.ErlangHandler, Logger.ErrorHandler, Logger.Formatter,
    Logger.Translator, Logger.Utils, Logger.Watcher]
  ```

  Duplicate applications are ignored:
  ```elixir
  iex> ApplicationX.modules([:logger, :logger])
  [Logger, Logger.App, Logger.BackendSupervisor, Logger.Backends.Console,
    Logger.Config, Logger.ErlangHandler, Logger.ErrorHandler, Logger.Formatter,
    Logger.Translator, Logger.Utils, Logger.Watcher]
  ```

  Unknown applications are safe to pass:
  ```elixir
  iex> ApplicationX.modules(:fake)
  []
  ```